### PR TITLE
code-action: insert padding when extracting multi-line string

### DIFF
--- a/src/providers/code-action-extract-string-to-fluent.ts
+++ b/src/providers/code-action-extract-string-to-fluent.ts
@@ -113,7 +113,13 @@ const commandExtractStringToFluent = {
           .find(group => group.name === groupName)
           ?.end
 
-        let insertCode = `\n${id} = ${selectedText}`
+        const paddedText = selectedText
+          .split('\n')
+          .map((line, index) => index === 0
+            ? line
+            : `    ${line}`)
+          .join('\n')
+        let insertCode = `\n${id} = ${paddedText}`
 
         if (groupOffsetEnd === undefined) {
           const positionEndFile = textDocument.lineAt(textDocument.lineCount - 1).range.end


### PR DESCRIPTION
When extracting a multi-line string, such as

```js
const text = `line1
line2
line3`
```

Was being added to Fluent the following:

```fluent
text = line1
line2
line3
```

But the correct is

```fluent
text = line1
    line2
    line3
```

This PR fixes that.