### PR TITLE
code-action: validate string before Ftl files check

### DIFF
--- a/src/providers/code-action-extract-string-to-fluent.ts
+++ b/src/providers/code-action-extract-string-to-fluent.ts
@@ -20,13 +20,13 @@ import { workspaceHasFtlFiles } from '../utils'
 const commandNameExtractStringToFluent = 'extractStringToFluent'
 
 const shouldDisplayCodeAction = async (selectedText: string) => {
-  const thereAreFtlFiles = await workspaceHasFtlFiles()
-  if (thereAreFtlFiles === false) {
+  const hasQuotesBordering = selectedText.match(/^(['"`]).*\1$/s)
+  if (hasQuotesBordering === null) {
     return false
   }
 
-  const hasQuotesBordering = selectedText.match(/^(['"`]).*\1$/s)
-  if (hasQuotesBordering === null) {
+  const thereAreFtlFiles = await workspaceHasFtlFiles()
+  if (thereAreFtlFiles === false) {
     return false
   }
 


### PR DESCRIPTION
We were running into the performance issues described in #27 and found that the file search was kicked off for every keystroke. As a stopgap, I'd like to propose that we move the `hasQuotesBordering` check before the file search. I verified that this prevents all the `rg` processes from spawning and fixes our performance issues.