### PR TITLE
feat: completion for message comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img height="350px" src="./docs/featured-image.png">
 </p>
 
-**Fluent** is a Mozilla's programming language for natural-sounding translations. And **vscode-fluent** is a VisualCode Studio extension to improve developer experience while working with this language.
+**Fluent** is a Mozilla's programming language for natural-sounding translations. And **vscode-fluent** is a Visual Studio Code extension to improve developer experience while working with this language.
 
 - 🌎 [Official Fluent's website](https://projectfluent.org/)
 - 📓 [Fluent Syntax Guide](https://www.projectfluent.org/fluent/guide/)
@@ -21,7 +21,7 @@
   - [🇺🇸 In English](https://youtu.be/kHHFcuQq70k?t=357)
   - [🇧🇷 In Portuguese](https://youtu.be/nJnAVUIyf5U?t=76)
 
-## Feature
+## Features
 
 - Syntax highlight
 - Show syntax errors
@@ -30,6 +30,7 @@
 - Hover support on messages
 - Breadcrumbs support
 - Go to message definition from a reference
+- Generate documentation comments for messages
 
 ## Code Action
 
@@ -39,12 +40,12 @@
   <img height="350px" src="./docs/extract-to-fluent.gif">
 </p>
 
-Using the code action "Extract to Fluent files" you can easly extract a string to from source code to all FTL files on your project.<br />
+Using the code action "Extract to Fluent files" you can easily extract a string to from source code to all FTL files on your project.<br />
 To open the code action menu, you should select a string (including its quotes) and then type `⌘ + .` (or `Ctrl + .`).
 
 You can change the replacement template using the configuration `vscodeFluent.replacementTemplate`.
 
-By default, the message will be added to all Fluent files on the workspace. But if you are working on a workspace with multiple projects, and each project has its Fluent files, you won't want mix messages between the projects. To avoid that, you should use the configuration `vscodeFluent.projects`, and add on it each projects's root path. See the bellow image for an instance.
+By default, the message will be added to all Fluent files on the workspace. But if you are working on a workspace with multiple projects, and each project has its Fluent files, you won't want mix messages between the projects. To avoid that, you should use the configuration `vscodeFluent.projects`, and add on it each projects' root path. See the below image for an instance.
 
 <p align="center">
   <img src="./docs/config-projects.png">
@@ -62,8 +63,8 @@ The syntax is written on a [YML file](./syntaxes/fluent.tmLanguage.yml). You can
 
 ### Extension
 
-You can run the extension using the `Run Extension` task on VSCode.
+You can run the extension using the `Run Extension` task on VS Code.
 
 ### Tests
 
-You can run the automated tests using the `Test Extension - No Workspace` and `Test Extension - With Workspace` tasks on VSCode.
+You can run the automated tests using the `Test Extension - No Workspace` and `Test Extension - With Workspace` tasks on VS Code.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import definitionProvider from './providers/definition'
 import documentSymbolProvider from './providers/document-symbol'
 import hoverProvider from './providers/hover'
 import { fileNameEndsWithFtl } from './utils'
+import completionProvider from './providers/completion'
 
 const activate = (_context: vscode.ExtensionContext) => {
   vscode.workspace.findFiles('**/*.ftl')
@@ -56,6 +57,7 @@ const activate = (_context: vscode.ExtensionContext) => {
   vscode.languages.registerDefinitionProvider('fluent', definitionProvider)
   vscode.languages.registerDocumentSymbolProvider('fluent', documentSymbolProvider)
   vscode.languages.registerHoverProvider('fluent', hoverProvider)
+  vscode.languages.registerCompletionItemProvider('fluent', completionProvider, '#')
 }
 
 const deactivate = () => {

--- a/src/global-state/index.ts
+++ b/src/global-state/index.ts
@@ -14,6 +14,7 @@ type GlobalState = {
     groupComments: Array<{ name: string, start: number, end: number }>
     referenceSpan: { [messageIdentifier in string]: Array<{ start: number, end: number }> }
     junksAnnotations: Array<{ code: string, message: string, start: number, end: number }>
+    variables: { [messageIdentifier in string]: Array<string> }
   }
 }
 
@@ -104,8 +105,17 @@ const isTermOrMessageReference = (path: string, identifier: string, position: nu
   return identifierSpan.some(isInMessageRange)
 }
 
+const isMessageSpan = (path: string, identifier: string, position: number) => {
+  const idSpan = globalState[path].idSpan[identifier]
+  if (idSpan === undefined) {
+    return false
+  }
+
+  return (position >= idSpan.start) && (position <= idSpan.end)
+}
+
 const getGroupComments = (path: string) =>
-  globalState[path].groupComments
+  globalState[path]?.groupComments
 
 const getAllGroupComments = () =>
   Object
@@ -114,6 +124,9 @@ const getAllGroupComments = () =>
 
 const getJunksAnnotations = (path: string) =>
   globalState[path].junksAnnotations
+
+const getDeclaredVariables = (path: string, message: string) =>
+  globalState[path].variables[message]
 
 const getAssociatedFluentFilesByFilePath = (path: string) => {
   if (globalProjectsFtls.isMultipleProjectWorkspace === false) {
@@ -144,8 +157,10 @@ export {
   getMessageValueSpan,
   getMessageHover,
   isTermOrMessageReference,
+  isMessageSpan,
   getGroupComments,
   getAllGroupComments,
   getJunksAnnotations,
+  getDeclaredVariables,
   getAssociatedFluentFilesByFilePath,
 }

--- a/src/global-state/index.ts
+++ b/src/global-state/index.ts
@@ -115,7 +115,7 @@ const isMessageSpan = (path: string, identifier: string, position: number) => {
 }
 
 const getGroupComments = (path: string) =>
-  globalState[path]?.groupComments
+  globalState[path]?.groupComments ?? []
 
 const getAllGroupComments = () =>
   Object

--- a/src/providers/completion.ts
+++ b/src/providers/completion.ts
@@ -1,0 +1,33 @@
+import { CompletionItem, CompletionItemKind, CompletionItemProvider, Position } from 'vscode'
+import { getIdentifierRangeAtPosition } from '../utils'
+import { getDeclaredVariables, isMessageSpan } from '../global-state'
+
+const completionProvider: CompletionItemProvider = {
+  provideCompletionItems(document, position, token, context) {
+    const comment = document.lineAt(position.line).text
+    if (comment.trimEnd() !== '#') {
+      return
+    }
+
+    // Find message on the next line.
+    const messagePosition = new Position(position.line + 1, 0)
+    const identifier = document.getText(getIdentifierRangeAtPosition(document, messagePosition))
+    if (isMessageSpan(document.uri.path, identifier, document.offsetAt(messagePosition)) === false) {
+      return
+    }
+
+    const initialSpace = comment.endsWith(' ') ? '' : ' '
+    const variableDocs = getDeclaredVariables(document.uri.path, identifier)
+      .map(variable => `${variable}: `)
+      .sort((a, b) => a.localeCompare(b))
+      .join('\n# ')
+
+    const item = new CompletionItem('Message comment', CompletionItemKind.Text)
+    item.sortText = '\0'
+    item.insertText = initialSpace + variableDocs
+
+    return [item]
+  },
+}
+
+export default completionProvider


### PR DESCRIPTION
Autocomplete when writing a comment above a message, automatically fill in all variable references so they can be documented (video is slightly outdated!):

![24-05-01_18-35-50_Code_Puffer](https://github.com/macabeus/vscode-fluent/assets/5117197/ac6122a5-3a43-40f2-a7fa-f74f742d8125)

I also fixed some typos in the readme :)